### PR TITLE
Add target_branches input to filter by PR base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,21 @@ Either is sufficient. The action exits successfully without calling the Linear A
 # .github/workflows/traceability.yaml
 name: traceability
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+    # no `branches:` filter — let `target_branches` (below) decide
 jobs:
   traceability:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - uses: neo4j/github-action-traceability@v3
         with:
           global_verification_strategy: linked
           github_api_token: ${{ secrets.GITHUB_TOKEN }}
           linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+          target_branches: |
+            dev
+            main
 ```
 
 ### Inputs
@@ -59,6 +62,9 @@ jobs:
 | `global_verification_strategy` | no | `linked` (default) or `disabled`. |
 | `github_api_token` | yes | GitHub token. The default `${{ secrets.GITHUB_TOKEN }}` works. |
 | `linear_api_key` | when strategy is `linked` | Linear personal API key. Create one at **Linear Settings → API → Personal API keys**. Store as a GitHub secret. |
+| `target_branches` | no | Newline-separated list of base branches the action should run against. PRs targeting any other base branch are reported as success without contacting Linear. Empty (default) means run for every base branch. |
+
+Prefer `target_branches` over a workflow-level `branches:` filter when PRs in your repo can be re-targeted between branches: the workflow filter only decides whether the workflow *runs*, so once a PR has failed against `dev` and is re-pointed elsewhere, the stale red check sticks. Letting the action gate on the base branch instead means the `edited` event re-fires on a base change and the most recent run paints the check green.
 
 ### Why a Linear API key (and not just OAuth)
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   linear_api_key:
     required: false
     description: "Linear API personal access token (Settings → API). Required when global_verification_strategy is 'linked'. Use GitHub secrets, do not paste plaintext."
+  target_branches:
+    required: false
+    default: ""
+    description: "Newline-separated list of base branches the action should run against. PRs whose base branch is not in the list are reported as success without contacting Linear. Empty (default) means run against all base branches. Useful when the consumer workflow cannot use the workflow-level `branches:` filter — e.g. so that changing the base branch of a PR re-paints the check status to green."
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -29977,6 +29977,7 @@ class GitHubClient {
             title
             body
             headRefName
+            baseRefName
             author {
               login
             }
@@ -29997,6 +29998,7 @@ class GitHubClient {
                 title: response.repository.pullRequest.title,
                 body: response.repository.pullRequest.body,
                 headRefName: response.repository.pullRequest.headRefName,
+                baseRefName: response.repository.pullRequest.baseRefName,
                 author: response.repository.pullRequest.author.login,
                 labels: response.repository.pullRequest.labels.edges.map((e) => e.node),
             };
@@ -30106,6 +30108,13 @@ class InputsClient {
             !github.context.payload.repository.owner.name)
             throw new Error((0, errors_1.ERR_INPUT_NOT_FOUND)('github.context.payload.repository.owner.login && github.context.payload.repository.owner.name'));
         return (github.context.payload.repository.owner.name || github.context.payload.repository.owner.login);
+    }
+    getTargetBranches() {
+        core.info('Get target_branches.');
+        return core
+            .getMultilineInput('target_branches')
+            .map((b) => b.trim())
+            .filter((b) => b.length > 0);
     }
     getPullRequestNumber() {
         core.info('Get github.context.payload.pull_request.number.');
@@ -30397,6 +30406,11 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         return;
     }
     const pullRequest = yield github.getPullRequest(inputs.getPullRequestNumber(), inputs.getGithubRepositoryOwner(), inputs.getGitHubRepositoryName());
+    const targetBranches = inputs.getTargetBranches();
+    if (targetBranches.length > 0 && !targetBranches.includes(pullRequest.baseRefName)) {
+        core.info(`Pull request base branch "${pullRequest.baseRefName}" is not in target_branches (${targetBranches.join(', ')}); skipping checks.`);
+        return;
+    }
     if (isOptedOut(pullRequest)) {
         core.info('Pull request is opted out of Linear traceability checks.');
         return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -30411,8 +30411,9 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         core.info(`Pull request base branch "${pullRequest.baseRefName}" is not in target_branches (${targetBranches.join(', ')}); skipping checks.`);
         return;
     }
-    if (isOptedOut(pullRequest)) {
-        core.info('Pull request is opted out of Linear traceability checks.');
+    const optOutReason = getOptOutReason(pullRequest);
+    if (optOutReason) {
+        core.info(`Pull request is opted out of Linear traceability checks via ${optOutReason}.`);
         return;
     }
     const candidateIds = extractIssueIds(pullRequest);
@@ -30436,21 +30437,23 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         if (existingIds.length === 0) {
             throw new Error((0, errors_1.ERR_ISSUE_NOT_FOUND)(candidateIds));
         }
-        const attached = results.some((r) => r.urls !== null && r.urls.some((u) => normalizeUrl(u) === prUrl));
-        if (attached) {
-            core.info('Pull request is attached to a Linear issue.');
+        const attachedIssue = results.find((r) => r.urls !== null && r.urls.some((u) => normalizeUrl(u) === prUrl));
+        if (attachedIssue) {
+            core.info(`Pull request is attached to Linear issue ${attachedIssue.id}.`);
             return;
         }
     }
     throw new Error((0, errors_1.ERR_ATTACHMENT_NOT_FOUND)(existingIds, pullRequest.url));
 });
 exports.run = run;
-const isOptedOut = (pullRequest) => {
-    if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL))
-        return true;
-    if (NOID_TITLE_PATTERN.test(pullRequest.title))
-        return true;
-    return false;
+const getOptOutReason = (pullRequest) => {
+    if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL)) {
+        return `the "No Linear" label`;
+    }
+    if (NOID_TITLE_PATTERN.test(pullRequest.title)) {
+        return `the [NOID] title prefix`;
+    }
+    return null;
 };
 const extractIssueIds = (pullRequest) => {
     var _a, _b;

--- a/lib/src/client-github.js
+++ b/lib/src/client-github.js
@@ -75,6 +75,7 @@ class GitHubClient {
             title
             body
             headRefName
+            baseRefName
             author {
               login
             }
@@ -95,6 +96,7 @@ class GitHubClient {
                 title: response.repository.pullRequest.title,
                 body: response.repository.pullRequest.body,
                 headRefName: response.repository.pullRequest.headRefName,
+                baseRefName: response.repository.pullRequest.baseRefName,
                 author: response.repository.pullRequest.author.login,
                 labels: response.repository.pullRequest.labels.edges.map((e) => e.node),
             };

--- a/lib/src/client-inputs.js
+++ b/lib/src/client-inputs.js
@@ -93,6 +93,13 @@ class InputsClient {
             throw new Error((0, errors_1.ERR_INPUT_NOT_FOUND)('github.context.payload.repository.owner.login && github.context.payload.repository.owner.name'));
         return (github.context.payload.repository.owner.name || github.context.payload.repository.owner.login);
     }
+    getTargetBranches() {
+        core.info('Get target_branches.');
+        return core
+            .getMultilineInput('target_branches')
+            .map((b) => b.trim())
+            .filter((b) => b.length > 0);
+    }
     getPullRequestNumber() {
         core.info('Get github.context.payload.pull_request.number.');
         if (!github.context.payload)

--- a/lib/src/run.js
+++ b/lib/src/run.js
@@ -57,6 +57,11 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         return;
     }
     const pullRequest = yield github.getPullRequest(inputs.getPullRequestNumber(), inputs.getGithubRepositoryOwner(), inputs.getGitHubRepositoryName());
+    const targetBranches = inputs.getTargetBranches();
+    if (targetBranches.length > 0 && !targetBranches.includes(pullRequest.baseRefName)) {
+        core.info(`Pull request base branch "${pullRequest.baseRefName}" is not in target_branches (${targetBranches.join(', ')}); skipping checks.`);
+        return;
+    }
     if (isOptedOut(pullRequest)) {
         core.info('Pull request is opted out of Linear traceability checks.');
         return;

--- a/lib/src/run.js
+++ b/lib/src/run.js
@@ -62,8 +62,9 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         core.info(`Pull request base branch "${pullRequest.baseRefName}" is not in target_branches (${targetBranches.join(', ')}); skipping checks.`);
         return;
     }
-    if (isOptedOut(pullRequest)) {
-        core.info('Pull request is opted out of Linear traceability checks.');
+    const optOutReason = getOptOutReason(pullRequest);
+    if (optOutReason) {
+        core.info(`Pull request is opted out of Linear traceability checks via ${optOutReason}.`);
         return;
     }
     const candidateIds = extractIssueIds(pullRequest);
@@ -87,21 +88,23 @@ const run = (inputs_1, github_1, linearFactory_1, ...args_1) => __awaiter(void 0
         if (existingIds.length === 0) {
             throw new Error((0, errors_1.ERR_ISSUE_NOT_FOUND)(candidateIds));
         }
-        const attached = results.some((r) => r.urls !== null && r.urls.some((u) => normalizeUrl(u) === prUrl));
-        if (attached) {
-            core.info('Pull request is attached to a Linear issue.');
+        const attachedIssue = results.find((r) => r.urls !== null && r.urls.some((u) => normalizeUrl(u) === prUrl));
+        if (attachedIssue) {
+            core.info(`Pull request is attached to Linear issue ${attachedIssue.id}.`);
             return;
         }
     }
     throw new Error((0, errors_1.ERR_ATTACHMENT_NOT_FOUND)(existingIds, pullRequest.url));
 });
 exports.run = run;
-const isOptedOut = (pullRequest) => {
-    if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL))
-        return true;
-    if (NOID_TITLE_PATTERN.test(pullRequest.title))
-        return true;
-    return false;
+const getOptOutReason = (pullRequest) => {
+    if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL)) {
+        return `the "No Linear" label`;
+    }
+    if (NOID_TITLE_PATTERN.test(pullRequest.title)) {
+        return `the [NOID] title prefix`;
+    }
+    return null;
 };
 const extractIssueIds = (pullRequest) => {
     var _a, _b;

--- a/lib/test/utils/dummy-client-github.js
+++ b/lib/test/utils/dummy-client-github.js
@@ -8,6 +8,7 @@ class GitHubClientBuilder {
         this.body = '';
         this.author = 'Alice';
         this.headRefName = 'feature/install-action';
+        this.baseRefName = 'dev';
         this.labels = [];
     }
     withPullRequestUrl(url) {
@@ -26,22 +27,27 @@ class GitHubClientBuilder {
         this.headRefName = headRefName;
         return this;
     }
+    withBaseRefName(baseRefName) {
+        this.baseRefName = baseRefName;
+        return this;
+    }
     withPullRequestLabel(name) {
         this.labels.push({ name });
         return this;
     }
     build() {
-        return new DummyGitHubClient(this.url, this.title, this.body, this.author, this.headRefName, this.labels);
+        return new DummyGitHubClient(this.url, this.title, this.body, this.author, this.headRefName, this.baseRefName, this.labels);
     }
 }
 exports.GitHubClientBuilder = GitHubClientBuilder;
 class DummyGitHubClient {
-    constructor(url, title, body, author, headRefName, labels) {
+    constructor(url, title, body, author, headRefName, baseRefName, labels) {
         this.url = url;
         this.title = title;
         this.body = body;
         this.author = author;
         this.headRefName = headRefName;
+        this.baseRefName = baseRefName;
         this.labels = labels;
     }
     getPullRequest(_pullRequestNumber, _repositoryOwner, _repositoryName) {
@@ -51,6 +57,7 @@ class DummyGitHubClient {
             body: this.body,
             author: this.author,
             headRefName: this.headRefName,
+            baseRefName: this.baseRefName,
             labels: this.labels,
         });
     }

--- a/lib/test/utils/dummy-client-inputs.js
+++ b/lib/test/utils/dummy-client-inputs.js
@@ -6,6 +6,7 @@ class InputsClientBuilder {
     constructor() {
         this.globalVerificationStrategy = client_inputs_1.GlobalVerificationStrategy.Linked;
         this.linearApiKey = 'fake-linear-api-key';
+        this.targetBranches = [];
     }
     withGlobalVerificationStrategy(strategy) {
         this.globalVerificationStrategy = strategy;
@@ -15,15 +16,20 @@ class InputsClientBuilder {
         this.linearApiKey = key;
         return this;
     }
+    withTargetBranches(branches) {
+        this.targetBranches = branches;
+        return this;
+    }
     build() {
-        return new DummyInputsClient(this.globalVerificationStrategy, this.linearApiKey);
+        return new DummyInputsClient(this.globalVerificationStrategy, this.linearApiKey, this.targetBranches);
     }
 }
 exports.InputsClientBuilder = InputsClientBuilder;
 class DummyInputsClient {
-    constructor(globalVerificationStrategy, linearApiKey) {
+    constructor(globalVerificationStrategy, linearApiKey, targetBranches) {
         this.globalVerificationStrategy = globalVerificationStrategy;
         this.linearApiKey = linearApiKey;
+        this.targetBranches = targetBranches;
     }
     getGlobalVerificationStrategy() {
         return this.globalVerificationStrategy;
@@ -42,5 +48,8 @@ class DummyInputsClient {
     }
     getPullRequestNumber() {
         return -1;
+    }
+    getTargetBranches() {
+        return this.targetBranches;
     }
 }

--- a/src/client-github.ts
+++ b/src/client-github.ts
@@ -19,6 +19,7 @@ interface PullRequest {
   body: string;
   author: string;
   headRefName: string;
+  baseRefName: string;
   labels: Label[];
 }
 
@@ -29,6 +30,7 @@ interface GetPullRequest {
       title: string;
       body: string;
       headRefName: string;
+      baseRefName: string;
       author: {
         login: string;
       };
@@ -82,6 +84,7 @@ class GitHubClient implements GitHubClientI {
             title
             body
             headRefName
+            baseRefName
             author {
               login
             }
@@ -103,6 +106,7 @@ class GitHubClient implements GitHubClientI {
       title: response.repository.pullRequest.title,
       body: response.repository.pullRequest.body,
       headRefName: response.repository.pullRequest.headRefName,
+      baseRefName: response.repository.pullRequest.baseRefName,
       author: response.repository.pullRequest.author.login,
       labels: response.repository.pullRequest.labels.edges.map((e) => e.node),
     };

--- a/src/client-inputs.ts
+++ b/src/client-inputs.ts
@@ -21,6 +21,7 @@ interface InputsClientI {
   getGitHubRepositoryName(): string;
   getGithubRepositoryOwner(): string;
   getPullRequestNumber(): number;
+  getTargetBranches(): string[];
 }
 
 class InputsClient implements InputsClientI {
@@ -81,6 +82,14 @@ class InputsClient implements InputsClientI {
     return (
       github.context.payload.repository.owner.name || github.context.payload.repository.owner.login
     );
+  }
+
+  getTargetBranches(): string[] {
+    core.info('Get target_branches.');
+    return core
+      .getMultilineInput('target_branches')
+      .map((b) => b.trim())
+      .filter((b) => b.length > 0);
   }
 
   getPullRequestNumber(): number {

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,6 +28,16 @@ const run = async (
     inputs.getGitHubRepositoryName(),
   );
 
+  const targetBranches = inputs.getTargetBranches();
+  if (targetBranches.length > 0 && !targetBranches.includes(pullRequest.baseRefName)) {
+    core.info(
+      `Pull request base branch "${
+        pullRequest.baseRefName
+      }" is not in target_branches (${targetBranches.join(', ')}); skipping checks.`,
+    );
+    return;
+  }
+
   if (isOptedOut(pullRequest)) {
     core.info('Pull request is opted out of Linear traceability checks.');
     return;

--- a/src/run.ts
+++ b/src/run.ts
@@ -38,8 +38,9 @@ const run = async (
     return;
   }
 
-  if (isOptedOut(pullRequest)) {
-    core.info('Pull request is opted out of Linear traceability checks.');
+  const optOutReason = getOptOutReason(pullRequest);
+  if (optOutReason) {
+    core.info(`Pull request is opted out of Linear traceability checks via ${optOutReason}.`);
     return;
   }
 
@@ -71,11 +72,11 @@ const run = async (
       throw new Error(ERR_ISSUE_NOT_FOUND(candidateIds));
     }
 
-    const attached = results.some(
+    const attachedIssue = results.find(
       (r) => r.urls !== null && r.urls.some((u) => normalizeUrl(u) === prUrl),
     );
-    if (attached) {
-      core.info('Pull request is attached to a Linear issue.');
+    if (attachedIssue) {
+      core.info(`Pull request is attached to Linear issue ${attachedIssue.id}.`);
       return;
     }
   }
@@ -83,10 +84,14 @@ const run = async (
   throw new Error(ERR_ATTACHMENT_NOT_FOUND(existingIds, pullRequest.url));
 };
 
-const isOptedOut = (pullRequest: PullRequest): boolean => {
-  if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL)) return true;
-  if (NOID_TITLE_PATTERN.test(pullRequest.title)) return true;
-  return false;
+const getOptOutReason = (pullRequest: PullRequest): string | null => {
+  if (pullRequest.labels.some((l) => l.name.trim().toLowerCase() === NO_LINEAR_LABEL)) {
+    return `the "No Linear" label`;
+  }
+  if (NOID_TITLE_PATTERN.test(pullRequest.title)) {
+    return `the [NOID] title prefix`;
+  }
+  return null;
 };
 
 const extractIssueIds = (pullRequest: PullRequest): string[] => {

--- a/test/strategy-linked.test.ts
+++ b/test/strategy-linked.test.ts
@@ -197,6 +197,51 @@ describe('GlobalVerificationStrategy.Linked', () => {
     });
   });
 
+  describe('target_branches', () => {
+    it('runs verification when target_branches is empty (no filter)', async () => {
+      const inputs = new InputsClientBuilder().build();
+      const github = new GitHubClientBuilder()
+        .withPullRequestUrl(PR_URL)
+        .withPullRequestTitle('[NEO-123] My feature')
+        .withBaseRefName('release/1.2')
+        .build();
+      const linear = new LinearClientBuilder().withAttachedPullRequest('NEO-123', PR_URL).build();
+      await expectSuccess(run(inputs, github, factoryOf(linear), NO_RETRY));
+    });
+
+    it('runs verification when the PR base branch is in target_branches', async () => {
+      const inputs = new InputsClientBuilder().withTargetBranches(['dev']).build();
+      const github = new GitHubClientBuilder()
+        .withPullRequestUrl(PR_URL)
+        .withPullRequestTitle('[NEO-123] My feature')
+        .withBaseRefName('dev')
+        .build();
+      const linear = new LinearClientBuilder().withAttachedPullRequest('NEO-123', PR_URL).build();
+      await expectSuccess(run(inputs, github, factoryOf(linear), NO_RETRY));
+    });
+
+    it('skips verification when the PR base branch is not in target_branches', async () => {
+      const inputs = new InputsClientBuilder().withTargetBranches(['dev']).build();
+      const github = new GitHubClientBuilder()
+        .withPullRequestTitle('No issue reference')
+        .withBaseRefName('2026.05')
+        .build();
+      const linear = new LinearClientBuilder().withAuthFailure().build();
+      await expectSuccess(run(inputs, github, factoryOf(linear), NO_RETRY));
+    });
+
+    it('matches against any entry when target_branches has multiple values', async () => {
+      const inputs = new InputsClientBuilder().withTargetBranches(['dev', 'main']).build();
+      const github = new GitHubClientBuilder()
+        .withPullRequestUrl(PR_URL)
+        .withPullRequestTitle('[NEO-123] My feature')
+        .withBaseRefName('main')
+        .build();
+      const linear = new LinearClientBuilder().withAttachedPullRequest('NEO-123', PR_URL).build();
+      await expectSuccess(run(inputs, github, factoryOf(linear), NO_RETRY));
+    });
+  });
+
   describe('disabled strategy', () => {
     it('is a no-op', async () => {
       const inputs = new InputsClientBuilder()

--- a/test/utils/dummy-client-github.ts
+++ b/test/utils/dummy-client-github.ts
@@ -6,6 +6,7 @@ class GitHubClientBuilder {
   body: string = '';
   author: string = 'Alice';
   headRefName: string = 'feature/install-action';
+  baseRefName: string = 'dev';
   labels: Label[] = [];
 
   public withPullRequestUrl(url: string): GitHubClientBuilder {
@@ -28,6 +29,11 @@ class GitHubClientBuilder {
     return this;
   }
 
+  public withBaseRefName(baseRefName: string): GitHubClientBuilder {
+    this.baseRefName = baseRefName;
+    return this;
+  }
+
   public withPullRequestLabel(name: string): GitHubClientBuilder {
     this.labels.push({ name });
     return this;
@@ -40,6 +46,7 @@ class GitHubClientBuilder {
       this.body,
       this.author,
       this.headRefName,
+      this.baseRefName,
       this.labels,
     );
   }
@@ -51,6 +58,7 @@ class DummyGitHubClient implements GitHubClientI {
   body: string;
   author: string;
   headRefName: string;
+  baseRefName: string;
   labels: Label[];
 
   constructor(
@@ -59,6 +67,7 @@ class DummyGitHubClient implements GitHubClientI {
     body: string,
     author: string,
     headRefName: string,
+    baseRefName: string,
     labels: Label[],
   ) {
     this.url = url;
@@ -66,6 +75,7 @@ class DummyGitHubClient implements GitHubClientI {
     this.body = body;
     this.author = author;
     this.headRefName = headRefName;
+    this.baseRefName = baseRefName;
     this.labels = labels;
   }
 
@@ -80,6 +90,7 @@ class DummyGitHubClient implements GitHubClientI {
       body: this.body,
       author: this.author,
       headRefName: this.headRefName,
+      baseRefName: this.baseRefName,
       labels: this.labels,
     });
   }

--- a/test/utils/dummy-client-inputs.ts
+++ b/test/utils/dummy-client-inputs.ts
@@ -3,6 +3,7 @@ import { GlobalVerificationStrategy, InputsClientI } from '../../src/client-inpu
 class InputsClientBuilder {
   globalVerificationStrategy: GlobalVerificationStrategy = GlobalVerificationStrategy.Linked;
   linearApiKey: string = 'fake-linear-api-key';
+  targetBranches: string[] = [];
 
   withGlobalVerificationStrategy(strategy: GlobalVerificationStrategy): InputsClientBuilder {
     this.globalVerificationStrategy = strategy;
@@ -14,18 +15,33 @@ class InputsClientBuilder {
     return this;
   }
 
+  withTargetBranches(branches: string[]): InputsClientBuilder {
+    this.targetBranches = branches;
+    return this;
+  }
+
   build(): InputsClientI {
-    return new DummyInputsClient(this.globalVerificationStrategy, this.linearApiKey);
+    return new DummyInputsClient(
+      this.globalVerificationStrategy,
+      this.linearApiKey,
+      this.targetBranches,
+    );
   }
 }
 
 class DummyInputsClient implements InputsClientI {
   globalVerificationStrategy: GlobalVerificationStrategy;
   linearApiKey: string;
+  targetBranches: string[];
 
-  constructor(globalVerificationStrategy: GlobalVerificationStrategy, linearApiKey: string) {
+  constructor(
+    globalVerificationStrategy: GlobalVerificationStrategy,
+    linearApiKey: string,
+    targetBranches: string[],
+  ) {
     this.globalVerificationStrategy = globalVerificationStrategy;
     this.linearApiKey = linearApiKey;
+    this.targetBranches = targetBranches;
   }
 
   getGlobalVerificationStrategy(): GlobalVerificationStrategy {
@@ -50,6 +66,10 @@ class DummyInputsClient implements InputsClientI {
 
   getPullRequestNumber(): number {
     return -1;
+  }
+
+  getTargetBranches(): string[] {
+    return this.targetBranches;
   }
 }
 


### PR DESCRIPTION
Lets the action be the gatekeeper for which base branches it runs against, instead of relying on the workflow-level `branches:` filter. When a PR's base is moved out of the list, the `edited` event re-fires the action and the most-recent check turns green — clearing stale failures that the workflow trigger filter would otherwise leave behind.